### PR TITLE
fix(swap): add minimum balance thresholds to prevent dust amount swaps

### DIFF
--- a/src/SwapAndBurn.sol
+++ b/src/SwapAndBurn.sol
@@ -52,7 +52,7 @@ contract SwapAndBurn {
 
         // ── ETH → WETH → CLAWD ───────────────────────────────────────────
         uint256 ethBal = address(this).balance;
-        if (ethBal > 0) {
+        if (ethBal >= 0.001 ether) {
             IWETH(address(WETH)).deposit{value: ethBal}();
             WETH.forceApprove(address(ROUTER), ethBal);
             totalClawd += ROUTER.exactInputSingle(
@@ -70,7 +70,7 @@ contract SwapAndBurn {
 
         // ── USDC → WETH → CLAWD (multihop) ───────────────────────────────
         uint256 usdcBal = USDC.balanceOf(address(this));
-        if (usdcBal > 0) {
+        if (usdcBal >= 1e6) {
             USDC.forceApprove(address(ROUTER), usdcBal);
             bytes memory path = abi.encodePacked(
                 address(USDC),


### PR DESCRIPTION
## Problem
As reported in #7, calling `execute()` when the contract holds only dust amounts (e.g., 1 wei of ETH) results in a swap that returns 0 CLAWD tokens due to pool math rounding. This wastes gas and opens up the contract to front-running griefers who could trigger swaps on dust amounts right before a large deposit lands.

## Solution  
Implemented the recommended minimum balance thresholds before triggering swaps:
- **ETH**: `ethBal >= 0.001 ether`
- **USDC**: `usdcBal >= 1e6` (1 USDC)

## Testing
Ran the Foundry test suite locally against the Base mainnet fork to verify that the threshold changes do not break the expected behavior for realistic swaps.

Closes #7